### PR TITLE
Update the link to the Github repo

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -70,6 +70,6 @@ paginate = 10
   twitter = "simplystats"
   facebook = ""
   instagram = ""
-  github = "simplystats"
+  github = "rbind/simplystats"
   stackoverflow = ""
   linkedin = ""


### PR DESCRIPTION
The link should be https://github.com/rbind/simplystats now.